### PR TITLE
Add 1.0.0 compatibility

### DIFF
--- a/dbtenv/__init__.py
+++ b/dbtenv/__init__.py
@@ -86,6 +86,8 @@ class Version(distutils.version.LooseVersion):
         version_match = re.match(r'(?P<version>\d+\.\d+\.\d+)(-?(?P<prerelease>[a-z].*))?', self.raw_version)
         self.is_semantic = version_match is not None
         self.is_stable = version_match is not None and not version_match['prerelease']
+        self.major_minor_patch = version_match['version'] if version_match is not None else None
+        self.prerelease = version_match['prerelease'] if version_match is not None else None
 
         # dbt pre-release versions are formatted slightly differently in PyPI and Homebrew.
         if version_match and version_match['prerelease']:

--- a/dbtenv/pip.py
+++ b/dbtenv/pip.py
@@ -84,7 +84,18 @@ class PipDbt(Dbt):
                 # Versions prior to 0.19.1 just specified agate>=1.6, but agate 1.6.2 introduced a dependency on PyICU
                 # which causes installation problems, so exclude that like versions 0.19.1 and above do.
                 pip_args.append('agate>=1.6,<1.6.2')
-            pip_args.append(f'dbt=={self.version.pypi_version}')
+
+            # Use correct dbt package name depending on version
+            if self.version < Version('1.0.0'):
+                pip_args.append(f'dbt=={self.version.pypi_version}')
+            else:
+                # See comment on adapter - dbt-core version coordination
+                # https://getdbt.slack.com/archives/C02HM9AAXL4/p1637345945047100?thread_ts=1637323222.046100&cid=C02HM9AAXL4
+                pip_args.append(f'dbt-core=={self.version.pypi_version}')
+                pip_args.append(f'dbt-postgres~={self.version.major_minor_patch}')
+                pip_args.append(f'dbt-redshift~={self.version.major_minor_patch}')
+                pip_args.append(f'dbt-snowflake~={self.version.major_minor_patch}')
+                pip_args.append(f'dbt-bigquery~={self.version.major_minor_patch}')
         logger.info(f"Installing dbt {self.version.pypi_version} from {package_source} into `{self.venv_directory}`.")
 
         logger.debug(f"Running `{pip}` with arguments {pip_args}.")


### PR DESCRIPTION
Adds compatibility for installing 1.0.0 via pip, with the existing behaviour of installing all the main adapters.

Resolves https://github.com/brooklyn-data/dbtenv/issues/4 (though we may have to remove brew support according to https://github.com/dbt-labs/docs.getdbt.com/pull/638/files#diff-2173d0ebb5138c6d50f74b3ece89cfbd514460c6293d1362db295e823b04909b)