### PR TITLE
Fix bad version comparison for jinja2 on dbt~=0.15.0

### DIFF
--- a/dbtenv/dbtenv/pip.py
+++ b/dbtenv/dbtenv/pip.py
@@ -130,7 +130,7 @@ class PipDbt(Dbt):
                     # Versions prior to 0.19.1 just specified agate>=1.6, but agate 1.6.2 introduced a dependency on PyICU
                     # which causes installation problems, so exclude that like versions 0.19.1 and above do.
                     pip_args.append('agate>=1.6,<1.6.2')
-                if self.version.pypi_version >= '0.15.0' < '0.16.0':
+                if '0.16.0' > self.version.pypi_version >= '0.15.0':
                     # Versions ~=0.15.0 just specified Jinja2>=2.10, but dbt versions ~=0.15.0 are not compatible with
                     # Jinja >= 3.0.0. https://github.com/dbt-labs/dbt-core/issues/2147
                     pip_args.append('Jinja2<3')


### PR DESCRIPTION
Resolves #38.

dbt~=0.15.0 had a loose pin for jinja2 so for these versions, a check had been added to force jinja2 < 3.0.  Unfortunately the logic had a bug where it forced the jinja version in all cases, not just the small version range.  This wasn't a problem up until now because dbt hadn't moved to jinja2>=3.0

dbt~=1.3.0 upgrades jinja2 to >= 3.0 which is why we started experiencing the issue now.